### PR TITLE
eslint: no-deprecated-api

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ drool.flow({
     driver.findElement(drool.webdriver.By.css('.destroy')).click();
   },
   assert: function(after, initial) {
-    assert.stict.equal(initial.counts.nodes, after.counts.nodes, 'node count should match');
+    assert.strict.equal(initial.counts.nodes, after.counts.nodes, 'node count should match');
   }
 }, driver)
 .then(() => driver.quit())

--- a/readme.md
+++ b/readme.md
@@ -57,7 +57,7 @@ drool.flow({
     driver.findElement(drool.webdriver.By.css('.destroy')).click();
   },
   assert: function(after, initial) {
-    assert.equal(initial.counts.nodes, after.counts.nodes, 'node count should match');
+    assert.stict.equal(initial.counts.nodes, after.counts.nodes, 'node count should match');
   }
 }, driver)
 .then(() => driver.quit())


### PR DESCRIPTION
ESLint: 'assert.qual' was deprecated since v10.0.0. Use `assert.strict.equal` instead.